### PR TITLE
Replacing closed filedescriptor of systemd

### DIFF
--- a/src/init-data
+++ b/src/init-data
@@ -72,4 +72,11 @@ set -x
 update-ca-trust
 )
 
+(
+	trap '' SIGHUP
+	mkdir -p /run/docker-console
+	(sleep infinity) &
+	ln -s /proc/$!/fd /run/docker-console/
+)
+
 exec /usr/sbin/init

--- a/src/init-django
+++ b/src/init-django
@@ -26,7 +26,7 @@ if [ "$$" -eq 1 ] ; then
 
 	systemd-tmpfiles --remove --create
 else
-	exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+	exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 fi
 
 cd /

--- a/src/init-ipa-server-install-options
+++ b/src/init-ipa-server-install-options
@@ -36,6 +36,13 @@ if ! [ -f /etc/ipa/ca.crt -a -f $DATA/ipa-server-install-options ] ; then
 EOS
 fi
 
+(
+	trap '' SIGHUP
+	mkdir -p /run/docker-console
+	(sleep infinity) &
+	ln -s /proc/$!/fd /run/docker-console/
+)
+
 export SHOW_LOG=1
 if [ -f /usr/sbin/init-data ] ; then
 	exec /usr/sbin/init-data

--- a/src/ipa-client-enroll
+++ b/src/ipa-client-enroll
@@ -10,7 +10,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 if [ -f /etc/ipa/default.conf ] ; then
 	echo "$HOSTNAME is already IPA-enrolled."

--- a/src/ipsilon-client-configure
+++ b/src/ipsilon-client-configure
@@ -10,7 +10,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 if [ -f /etc/httpd/saml2/$HOSTNAME/metadata.xml ] ; then
 	echo "Ipsilon client is already configured on $HOSTNAME."

--- a/src/ipsilon-server-configure
+++ b/src/ipsilon-server-configure
@@ -9,7 +9,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 if [ -f /etc/httpd/conf.d/ipsilon-idp.conf ] ; then
 	echo "Ipsilon IdP is already configured on $HOSTNAME."

--- a/src/populate-data-volume
+++ b/src/populate-data-volume
@@ -9,7 +9,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 if [ -f /data/volume-version ] ; then
 	echo "The data volume is already populated on $HOSTNAME."

--- a/src/setup-authorized-keys
+++ b/src/setup-authorized-keys
@@ -8,7 +8,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 if [ -f /data/id_rsa ] ; then
 	echo "The ssh key was already generated on $HOSTNAME."

--- a/src/www-setup-apache
+++ b/src/www-setup-apache
@@ -10,7 +10,7 @@
 
 set -e
 
-exec >> /proc/1/fd/1 2>> /proc/1/fd/2
+exec >> /run/docker-console/fd/1 2>> /run/docker-console/fd/2
 
 set -x
 echo "$(dig +short @127.0.0.11 app.example.test) app.example.test" >> /etc/hosts


### PR DESCRIPTION
systemd filedescriptor is closed on fedora 25+.
Replacing with created sleeping process' filedescriptor, to redirect output to client's terminal.